### PR TITLE
fix LV2 generating on headless system

### DIFF
--- a/VASTvaporizer/Source/Plugin/VASTAudioProcessorEditor.cpp
+++ b/VASTvaporizer/Source/Plugin/VASTAudioProcessorEditor.cpp
@@ -16,11 +16,14 @@
 VASTAudioProcessorEditor::VASTAudioProcessorEditor(VASTAudioProcessor& p)
 	: AudioProcessorEditor(&p), processor(p) {
 
-	juce::Rectangle<int> r = Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea;
-	int screenW = r.getWidth();
-	int screenH = r.getHeight();
-	if (m_iMaxWidth > screenW) m_iMaxWidth = screenW;
-	if (m_iMaxHeight > screenH) m_iMaxHeight = screenH;
+		if (juce::Desktop::getInstance().isHeadless() == false)
+		{
+			juce::Rectangle<int> r = Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea;
+			int screenW = r.getWidth();
+			int screenH = r.getHeight();
+			if (m_iMaxWidth > screenW) m_iMaxWidth = screenW;
+			if (m_iMaxHeight > screenH) m_iMaxHeight = screenH;
+		}
 
 	resizeCalledFromConstructor = true;
 

--- a/VASTvaporizer/Source/Plugin/VASTFX/VASTFXEffectPane.cpp
+++ b/VASTvaporizer/Source/Plugin/VASTFX/VASTFXEffectPane.cpp
@@ -83,7 +83,10 @@ void VASTFXEffectPane::resized()
     //[/UserPreResize]
 
     //[UserResized] Add your own custom resize handling here..
-	updateGUI("", false);
+if (juce::Desktop::getInstance().isHeadless() == false)
+    {
+		updateGUI("", false);
+	}
     //[/UserResized]
 }
 


### PR DESCRIPTION
during LV2 build the plugin is instantiated for generating .ttl files, this requires an ability to run without display