### PR TITLE
Add CLAP plugin support in CMakeLists.txt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "VASTvaporizer/Source/AnaMark-Tuning-Library"]
 	path = VASTvaporizer/Source/AnaMark-Tuning-Library
 	url = https://github.com/zardini123/AnaMark-Tuning-Library
+[submodule "clap-juce-extensions"]
+	path = clap-juce-extensions
+	url = https://github.com/free-audio/clap-juce-extensions.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ else()
   find_package(JUCE CONFIG REQUIRED)
 endif(NOT USE_SYSTEM_JUCE)
 
+add_subdirectory(clap-juce-extensions ${CMAKE_BINARY_DIR}/clap-juce-extensions EXCLUDE_FROM_ALL)
+
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 if(AAX_SDK_LOCATION)
@@ -75,6 +77,11 @@ juce_add_plugin(${PROJECT_NAME}
   ICON_BIG "VASTvaporizer/Resources/logokreisvdalpha.png"
   ICON_SMALL "VASTvaporizer/Resources/logokreisvdalpha.png"  
   PLUGINHOST_AU FALSE
+)
+
+clap_juce_extensions_plugin(TARGET ${PROJECT_NAME}
+        CLAP_ID "com.vastdynamics.VAST2"
+        CLAP_FEATURES instrument
 )
 
 juce_generate_juce_header(${PROJECT_NAME})


### PR DESCRIPTION
context: https://github.com/VASTDynamics/Vaporizer2/issues/3

I'm not sure if this simple and straightforward change suffices, but at least it builds and seems to load on Reaper on my M2 mac.