### PR TITLE
Fix race condition causing use-after-free bugs

### DIFF
--- a/VASTvaporizer/Source/Plugin/VASTPreset/VASTPresetData.cpp
+++ b/VASTvaporizer/Source/Plugin/VASTPreset/VASTPresetData.cpp
@@ -30,6 +30,8 @@ VASTPresetData::VASTPresetData(VASTAudioProcessor* proc) : myProcessor(proc) {
 
 VASTPresetData::~VASTPresetData()
 {
+	if (m_reloadPresetThread.joinable())
+		m_reloadPresetThread.join();
 	VASTPresetData::isLoadThreadRunning = false;
 }
 
@@ -239,8 +241,7 @@ void VASTPresetData::reloadPresetArray(bool synchronous) {
 		swapPresetArraysIfNeeded();
 	}
 	else {
-		std::thread reloadPresetthread(&VASTPresetData::reloadPresetArrayThreaded, SafePointer<VASTPresetData>(this), myProcessor);
-		reloadPresetthread.detach();
+		m_reloadPresetThread = std::thread(&VASTPresetData::reloadPresetArrayThreaded, SafePointer<VASTPresetData>(this), myProcessor);
 	}
 }
 

--- a/VASTvaporizer/Source/Plugin/VASTPreset/VASTPresetData.h
+++ b/VASTvaporizer/Source/Plugin/VASTPreset/VASTPresetData.h
@@ -11,6 +11,7 @@
 #include "../../Engine/VASTEngineHeader.h"
 #include "VASTPresetElement.h"
 #include <map>
+#include <thread>
 #include <unordered_map>
 
 class VASTAudioProcessor; //forward declaration
@@ -107,6 +108,7 @@ private:
 	StringArray swap_usedTags;
 	std::atomic<bool> m_swapNeeded = false;
 
+	std::thread m_reloadPresetThread;
 	CriticalSection m_arraySwapLock;
 
 	int m_numFavorites[5];


### PR DESCRIPTION
When the plugin is instantiated, it starts loading preset data on a separate thread. If the plugin is destroyed before the thread finishes, the thread ends up accessing memory that was already deallocated, leading to use-after-free memory violations.

This issue is particularly likely to occur in `juce_vst3_helper` (automatically run as part of the build process), which instantiates the plugin in order to call `getVST3ClientExtensions()` but then almost immediately destroys it. The preset loading thread is likely still running at that point. This has led to errors during the build process like:

* `malloc(): unaligned fastbin chunk detected`
* `malloc(): smallbin double linked list corrupted`
* Errors from JUCE’s `LeakedObjectDetector`
* Segmentation faults
* Build process hanging indefinitely

This PR modifies the destructor of `VASTPresetData` so that it waits for the thread to finish, if necessary. So far this has appeared to resolve the issue.